### PR TITLE
Allow Query String Parameters for Events API

### DIFF
--- a/lib/model/Events.js
+++ b/lib/model/Events.js
@@ -27,10 +27,20 @@ Events.prototype.setEndPoint = function (endPoint) {
  * {@link http://apidocs.cloudfoundry.org/214/events/list_all_events.html}
  * @param  {String} token_type   [Authentication type]
  * @param  {String} access_token [Authentication token]
+ * @param  {Object} events_options [Query String Parameters]
  * @return {JSON}              [return a JSON response]
  */
-Events.prototype.getEvents = function (token_type, access_token) {
+Events.prototype.getEvents = function (token_type, access_token, event_options) {
     "use strict";
+
+    var qs = {
+      'results-per-page': 10
+    };
+
+    if (event_options) {
+      qs = event_options;
+    }
+
     var url = this.API_URL + "/v2/events";
     var options = {
         method: 'GET',
@@ -38,9 +48,8 @@ Events.prototype.getEvents = function (token_type, access_token) {
         headers: {
             Authorization: token_type + ' ' + access_token
         },
-        qs: {
-            'results-per-page': 10
-        }
+        qs: qs,
+        useQuerystring: true
     };
 
     return this.REST.request(options, "200", true);

--- a/test/lib/model/EventsTests.js
+++ b/test/lib/model/EventsTests.js
@@ -49,7 +49,20 @@ describe("Cloud foundry Events", function () {
 
         return CloudFoundryEvents.getEvents(token_type, access_token).then(function (result) {
             expect(result.total_results).is.a("number");
+            expect(result.resources.length).to.equal(10);
         });
     });
 
+    it("The platform returns the Events With Optional Query String Parameters", function () {
+      this.timeout(100000);
+
+      var event_options = {
+        'results-per-page': 20
+      };
+
+      return CloudFoundryEvents.getEvents(token_type, access_token, event_options).then(function (result) {
+        expect(result.total_results).is.a("number");
+        expect(result.resources.length).to.equal(20);
+      });
+    });
 });


### PR DESCRIPTION
Events API allows for a query parameters that modify the results.
https://apidocs.cloudfoundry.org/223/events/list_all_events.html

Add optional parameter to *Events* model to allow for users to set the values.

