### PR TITLE
creates a zip file on the fly if a folder is passed in

### DIFF
--- a/lib/model/cloudcontroller/Apps.js
+++ b/lib/model/cloudcontroller/Apps.js
@@ -3,6 +3,7 @@
 const CloudControllerBase = require("./CloudControllerBase");
 const rest = require("restler");//TODO: Analyze a way to remove this dependency
 const fs = require("fs");
+const AdmZip = require("adm-zip");
 
 /**
  * This public class manages the operations related with Applications on Cloud Controller.
@@ -267,7 +268,7 @@ class Apps extends CloudControllerBase {
                 asyncFlag = true;
             }
         }
-        const options = {
+        var options = {
             multipart: true,
             accessToken: this.UAA_TOKEN.access_token,
             query: {
@@ -280,7 +281,16 @@ class Apps extends CloudControllerBase {
             }
         };
 
-        return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
+        if (stats.isDirectory()) {
+            var zip = new AdmZip();
+            zip.addLocalFolder(filePath);
+            var willSendthis = zip.toBuffer();
+            options.data.application = rest.data(null, "application/zip", willSendthis);
+            return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
+        }
+        else {
+            return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
+        }
     }
 
 

--- a/lib/model/cloudcontroller/Apps.js
+++ b/lib/model/cloudcontroller/Apps.js
@@ -262,6 +262,10 @@ class Apps extends CloudControllerBase {
         const fileSizeInBytes = stats.size;
         const zipResources = [];
         let asyncFlag = false;
+        var zip = new AdmZip();
+
+        zip.addLocalFolder(filePath);
+        var zipBuffer = zip.toBuffer();
 
         if (typeof async === "boolean") {
             if (async) {
@@ -282,15 +286,9 @@ class Apps extends CloudControllerBase {
         };
 
         if (stats.isDirectory()) {
-            var zip = new AdmZip();
-            zip.addLocalFolder(filePath);
-            var willSendthis = zip.toBuffer();
-            options.data.application = rest.data(null, "application/zip", willSendthis);
-            return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
+            options.data.application = rest.data(null, "application/zip", zipBuffer);
         }
-        else {
-            return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
-        }
+        return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
     }
 
 

--- a/lib/model/cloudcontroller/Apps.js
+++ b/lib/model/cloudcontroller/Apps.js
@@ -264,9 +264,6 @@ class Apps extends CloudControllerBase {
         let asyncFlag = false;
         var zip = new AdmZip();
 
-        zip.addLocalFolder(filePath);
-        var zipBuffer = zip.toBuffer();
-
         if (typeof async === "boolean") {
             if (async) {
                 asyncFlag = true;
@@ -286,7 +283,8 @@ class Apps extends CloudControllerBase {
         };
 
         if (stats.isDirectory()) {
-            options.data.application = rest.data(null, "application/zip", zipBuffer);
+            zip.addLocalFolder(filePath);
+            options.data.application = rest.data(null, "application/zip", zip.toBuffer());
         }
         return this.REST.upload(url, options, this.HttpStatus.CREATED, false);
     }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lib"
   ],
   "dependencies": {
+    "adm-zip": "^0.4.7",
     "bluebird": "3.0.6",
     "request": "2.67.0",
     "restler": "3.4.0"


### PR DESCRIPTION
The CF cli creates a zip file on the fly when you push an app, this PR adds the same functionality, it creates a zip file on the file if a folder is passed to the upload function.  The zip file is created in memory and then passed as a buffer in memory to restler for the upload.

resolves #169 